### PR TITLE
Disable magic nx cache because it is no longer supported on anything …

### DIFF
--- a/.github/workflows/check-pre-commit.yaml
+++ b/.github/workflows/check-pre-commit.yaml
@@ -6,6 +6,9 @@ on:
 jobs:
   pre-commit-hooks:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -17,8 +20,8 @@ jobs:
         with:
           extra_nix_config: |
             accept-flake-config = true
-            extra-substituters =
-            trusted-public-keys =
-      
+
+      - uses: DeterminateSystems/flakehub-cache-action@main
+
       - name: Run pre-commit hooks
         run: nix develop --impure --command pre-commit run --all-files

--- a/.github/workflows/check-pre-commit.yaml
+++ b/.github/workflows/check-pre-commit.yaml
@@ -17,8 +17,8 @@ jobs:
         with:
           extra_nix_config: |
             accept-flake-config = true
+            extra-substituters =
+            trusted-public-keys =
       
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-
       - name: Run pre-commit hooks
         run: nix develop --impure --command pre-commit run --all-files

--- a/.github/workflows/check-pre-commit.yaml
+++ b/.github/workflows/check-pre-commit.yaml
@@ -12,9 +12,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - uses: jashandeep-sohi/action-cache-api-shim@v1
-
+        
       - name: Install nix
         uses: cachix/install-nix-action@v24
         with:

--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -128,7 +128,6 @@ jobs:
       group: cd-update
 
     steps:
-      - uses: jashandeep-sohi/action-cache-api-shim@v1
       - name: Get a token as lco-deploy-bot
         uses: actions/create-github-app-token@v1
         id: lco-deploy-bot

--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -120,6 +120,9 @@ jobs:
       deployOrgRepo: ${{ (inputs.deployRepo && format('{0}/{1}', github.repository_owner, inputs.deployRepo)) || format('{0}-deploy', github.repository) }}
     runs-on: ubuntu-latest
     needs: container
+    permissions:
+      id-token: write
+      contents: read
     concurrency:
       group: cd-update
 
@@ -144,8 +147,8 @@ jobs:
         with:
           extra_nix_config: |
             accept-flake-config = true
-            extra-substituters =
-            trusted-public-keys =
+            
+      - uses: DeterminateSystems/flakehub-cache-action@main
 
       - name: Configure Git to use lco-deploy-bot token
         run: |

--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -83,8 +83,8 @@ jobs:
         with:
           extra_nix_config: |
             accept-flake-config = true
-
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+            extra-substituters =
+            trusted-public-keys =
 
       - name: Login to Container Registry
         uses: docker/login-action@v3
@@ -144,8 +144,8 @@ jobs:
         with:
           extra_nix_config: |
             accept-flake-config = true
-
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+            extra-substituters =
+            trusted-public-keys =
 
       - name: Configure Git to use lco-deploy-bot token
         run: |

--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -83,9 +83,9 @@ jobs:
         with:
           extra_nix_config: |
             accept-flake-config = true
-            extra-substituters =
-            trusted-public-keys =
 
+      - uses: DeterminateSystems/flakehub-cache-action@main
+       
       - name: Login to Container Registry
         uses: docker/login-action@v3
         with:
@@ -147,7 +147,7 @@ jobs:
         with:
           extra_nix_config: |
             accept-flake-config = true
-            
+
       - uses: DeterminateSystems/flakehub-cache-action@main
 
       - name: Configure Git to use lco-deploy-bot token

--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -52,6 +52,7 @@ jobs:
 
     permissions:
       packages: write
+      id-token: write
       contents: read
 
     env:
@@ -85,7 +86,7 @@ jobs:
             accept-flake-config = true
 
       - uses: DeterminateSystems/flakehub-cache-action@main
-       
+
       - name: Login to Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/sync-deploy-output.yaml
+++ b/.github/workflows/sync-deploy-output.yaml
@@ -34,8 +34,8 @@ jobs:
 
       - uses: DeterminateSystems/determinate-nix-action@v3
       - uses: DeterminateSystems/flakehub-cache-action@main
-          
-          - name: Run pre-commit hooks
+
+      - name: Run pre-commit hooks
         run: nix develop --impure --command pre-commit run --all-files
         continue-on-error: true
 

--- a/.github/workflows/sync-deploy-output.yaml
+++ b/.github/workflows/sync-deploy-output.yaml
@@ -8,6 +8,9 @@ on:
 jobs:
   sync-output:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/create-github-app-token@v1
         id: lco-deploy-bot

--- a/.github/workflows/sync-deploy-output.yaml
+++ b/.github/workflows/sync-deploy-output.yaml
@@ -33,8 +33,6 @@ jobs:
 
       - uses: DeterminateSystems/determinate-nix-action@v3
       - uses: DeterminateSystems/flakehub-cache-action@main
-      - name: Install determinate-nixd
-        run: nix profile install github:DeterminateSystems/determinate-nixd
 
       - name: Run pre-commit hooks
         run: nix develop --impure --command pre-commit run --all-files

--- a/.github/workflows/sync-deploy-output.yaml
+++ b/.github/workflows/sync-deploy-output.yaml
@@ -6,10 +6,6 @@ on:
   workflow_call:
 
 jobs:
-  ci:
-    permissions:
-      id-token: write
-      contents: read
   sync-output:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sync-deploy-output.yaml
+++ b/.github/workflows/sync-deploy-output.yaml
@@ -34,7 +34,7 @@ jobs:
       - uses: DeterminateSystems/determinate-nix-action@v3
       - uses: DeterminateSystems/flakehub-cache-action@main
       - name: Install determinate-nixd
-        run: nix profile install github:DeterminateSystems/determinate-nix
+        run: nix profile install github:DeterminateSystems/determinate-nixd
 
       - name: Run pre-commit hooks
         run: nix develop --impure --command pre-commit run --all-files

--- a/.github/workflows/sync-deploy-output.yaml
+++ b/.github/workflows/sync-deploy-output.yaml
@@ -33,6 +33,8 @@ jobs:
 
       - uses: DeterminateSystems/determinate-nix-action@v3
       - uses: DeterminateSystems/flakehub-cache-action@main
+      - name: Install determinate-nixd
+        run: nix profile install github:DeterminateSystems/determinate-nix#determinate-nixd
 
       - name: Run pre-commit hooks
         run: nix develop --impure --command pre-commit run --all-files

--- a/.github/workflows/sync-deploy-output.yaml
+++ b/.github/workflows/sync-deploy-output.yaml
@@ -31,7 +31,6 @@ jobs:
           extra_nix_config: |
             accept-flake-config = true
 
-      - uses: DeterminateSystems/determinate-nix-action@v3
       - uses: DeterminateSystems/flakehub-cache-action@main
 
       - name: Run pre-commit hooks

--- a/.github/workflows/sync-deploy-output.yaml
+++ b/.github/workflows/sync-deploy-output.yaml
@@ -6,11 +6,11 @@ on:
   workflow_call:
 
 jobs:
+  ci:
+    permissions:
+      id-token: write
+      contents: read
   sync-output:
-    ci:
-      permissions:
-        id-token: write
-        contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v1

--- a/.github/workflows/sync-deploy-output.yaml
+++ b/.github/workflows/sync-deploy-output.yaml
@@ -7,6 +7,10 @@ on:
 
 jobs:
   sync-output:
+    ci:
+      permissions:
+        id-token: write
+        contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v1
@@ -27,10 +31,11 @@ jobs:
         with:
           extra_nix_config: |
             accept-flake-config = true
-            extra-substituters =
-            trusted-public-keys =
 
-      - name: Run pre-commit hooks
+      - uses: DeterminateSystems/determinate-nix-action@v3
+      - uses: DeterminateSystems/flakehub-cache-action@main
+          
+          - name: Run pre-commit hooks
         run: nix develop --impure --command pre-commit run --all-files
         continue-on-error: true
 

--- a/.github/workflows/sync-deploy-output.yaml
+++ b/.github/workflows/sync-deploy-output.yaml
@@ -34,7 +34,7 @@ jobs:
       - uses: DeterminateSystems/determinate-nix-action@v3
       - uses: DeterminateSystems/flakehub-cache-action@main
       - name: Install determinate-nixd
-        run: nix profile install github:DeterminateSystems/determinate-nix#determinate-nixd
+        run: nix profile install github:DeterminateSystems/determinate-nix
 
       - name: Run pre-commit hooks
         run: nix develop --impure --command pre-commit run --all-files

--- a/.github/workflows/sync-deploy-output.yaml
+++ b/.github/workflows/sync-deploy-output.yaml
@@ -24,7 +24,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ steps.lco-deploy-bot.outputs.token }}
 
-      - uses: jashandeep-sohi/action-cache-api-shim@v1
       - name: Install nix
         uses: cachix/install-nix-action@v24
         with:

--- a/.github/workflows/sync-deploy-output.yaml
+++ b/.github/workflows/sync-deploy-output.yaml
@@ -27,8 +27,8 @@ jobs:
         with:
           extra_nix_config: |
             accept-flake-config = true
-      
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+            extra-substituters =
+            trusted-public-keys =
 
       - name: Run pre-commit hooks
         run: nix develop --impure --command pre-commit run --all-files


### PR DESCRIPTION
…less than Github enterprise.
Switch to using flakehub cache because they generously offered us a free account.